### PR TITLE
[Feat] 실시간 과제, 출결 랭킹 조회

### DIFF
--- a/src/main/java/com/club/magazine_club_program/Controller/ManagementController.java
+++ b/src/main/java/com/club/magazine_club_program/Controller/ManagementController.java
@@ -64,4 +64,11 @@ public class ManagementController {
             return ResponseEntity.status(404).body(id + ": " + "과제 업데이트 실패");
         }
     }
+
+    // 출석, 과제 랭킹
+    @GetMapping("/ranking")
+    public ResponseEntity<List<String>> getRanking() {
+        List<ManagementDTO> list = managementService.getAllMemberStat();
+        return ResponseEntity.ok(managementService.getRanking(list, memberService));
+    }
 }

--- a/src/main/java/com/club/magazine_club_program/DTO/ManagementDTO.java
+++ b/src/main/java/com/club/magazine_club_program/DTO/ManagementDTO.java
@@ -1,9 +1,9 @@
 package com.club.magazine_club_program.DTO;
 
 public class ManagementDTO {
-    private final int id;
-    private boolean isAttendance;
-    private boolean isTask;
+    private final Integer id;
+    private Boolean isAttendance;
+    private Boolean isTask;
     private String name;
 
     public ManagementDTO(int id, boolean isAttendance, boolean isTask) {

--- a/src/main/java/com/club/magazine_club_program/Service/ManagementService.java
+++ b/src/main/java/com/club/magazine_club_program/Service/ManagementService.java
@@ -2,11 +2,8 @@ package com.club.magazine_club_program.Service;
 
 import com.club.magazine_club_program.DTO.ManagementDTO;
 import com.club.magazine_club_program.Mapper.ManagementMapper;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-
+import java.util.*;
 
 @Service
 public class ManagementService {
@@ -23,17 +20,44 @@ public class ManagementService {
 
     // 출석 상태 업데이트
     public boolean updateAttendance(ManagementDTO managementDTO) {
-        managementDTO.setAttendance(managementDTO.isAttendance());
-        int Updated = managementMapper.updateAttendance(managementDTO.getId(), managementDTO.isAttendance());
-        ResponseEntity.ok();
-        return Updated > 0;
+        int updatedRows = managementMapper.updateAttendance(managementDTO.getId(), managementDTO.isAttendance());
+        return updatedRows > 0;
     }
 
     // 과제 상태 업데이트
     public boolean updateTask(ManagementDTO managementDTO) {
-        managementDTO.setTask(managementDTO.isTask());
-        int Updated = managementMapper.updateTask(managementDTO.getId(), managementDTO.isTask());
-        ResponseEntity.ok();
-        return Updated > 0;
+        int updatedRows = managementMapper.updateTask(managementDTO.getId(), managementDTO.isTask());
+        return updatedRows > 0;
+    }
+
+    // 출석 및 과제 랭킹 계산
+    public List<String> getRanking(List<ManagementDTO> managementList, MemberService memberService) {
+        Map<Integer, Integer> attendanceMap = new HashMap<>();
+        Map<Integer, Integer> taskMap = new HashMap<>();
+
+        // 출석 및 과제 횟수 집계
+        for (ManagementDTO dto : managementList) {
+            int id = dto.getId();
+            attendanceMap.put(id, attendanceMap.getOrDefault(id, 0) + (dto.isAttendance() ? 1 : 0));
+            taskMap.put(id, taskMap.getOrDefault(id, 0) + (dto.isTask() ? 1 : 0));
+        }
+
+        Set<Integer> allIds = new HashSet<>(attendanceMap.keySet());
+        allIds.addAll(taskMap.keySet());
+
+        // 정렬: 출석 순 -> 과제 순
+        List<Integer> sortedIds = new ArrayList<>(allIds);
+        sortedIds.sort(Comparator
+                .comparing((Integer id) -> attendanceMap.getOrDefault(id, 0)).reversed()
+                .thenComparing(id -> taskMap.getOrDefault(id, 0), Comparator.reverseOrder()));
+
+        List<String> result = new ArrayList<>();
+        for (int id : sortedIds) {
+            int attendance = attendanceMap.getOrDefault(id, 0);
+            int task = taskMap.getOrDefault(id, 0);
+            result.add(String.format("ID: %d |  %d |  %d", id, attendance, task));
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
id를 key값으로 하여  출결, 과제 랭킹을 실시간 조회하는 기능을 추가 했습니다.
모임의 특성상 월 1회 짧은 만남이 이루어지므로, 시간별 랭킹 갱신은 큰 의미가 없다고 판단되어 넣지 않았습니다.
<img width="1276" alt="스크린샷 2025-03-24 오후 8 04 21" src="https://github.com/user-attachments/assets/6e10ab2a-ba2d-4da5-8c17-6faf70e05cba" />
