### PR TITLE
[Feat] sns 이미지 크롤러 메인브랜치 병합

### DIFF
--- a/src/main/java/com/club/magazine_club_program/Controller/MemberController.java
+++ b/src/main/java/com/club/magazine_club_program/Controller/MemberController.java
@@ -17,7 +17,7 @@ public class MemberController {
         this.memberService = memberService;
     }
 
-    // 전체 멤버 조회
+    // 전체 멤버 조회 
     @GetMapping
     public ResponseEntity<?> getAllMembers() {
         try {
@@ -28,14 +28,55 @@ public class MemberController {
         }
     }
 
+    // SNS 링크가 있는 멤버만 조회
+    @GetMapping("/with-sns")
+    public ResponseEntity<?> getMembersWithSNS() {
+        try {
+            List<MemberDTO> members = memberService.getMembersWithSNS();
+            return ResponseEntity.ok(members);
+        } catch (Exception e) {
+            return ResponseEntity.ok("SNS 링크가 있는 멤버 조회 실패: " + e.getMessage());
+        }
+    }
+
     // 멤버 추가
     @PostMapping("/addMember")
     public ResponseEntity<?> addMember(@RequestBody MemberDTO memberDTO) {
         try {
             memberService.addMember(memberDTO);
-            return ResponseEntity.ok( memberDTO.getName() + "추가");
+            return ResponseEntity.ok(memberDTO.getName() + " 추가");
         } catch (Exception e) {
             return ResponseEntity.ok("멤버 추가 실패: " + e.getMessage());
+        }
+    }
+
+    // 멤버 SNS 링크 업데이트
+    @PutMapping("/update-sns")
+    public ResponseEntity<?> updateMemberSNS(@RequestBody MemberDTO memberDTO) {
+        try {
+            boolean isUpdated = memberService.updateMemberSNS(memberDTO);
+            if (isUpdated) {
+                return ResponseEntity.ok("SNS 링크 업데이트 성공");
+            } else {
+                return ResponseEntity.ok("SNS 링크 업데이트 실패: 해당 ID를 찾을 수 없음");
+            }
+        } catch (Exception e) {
+            return ResponseEntity.ok("SNS 링크 업데이트 실패: " + e.getMessage());
+        }
+    }
+
+    // 멤버 SNS 링크 삭제
+    @DeleteMapping("/delete-sns/{id}")
+    public ResponseEntity<?> deleteMemberSNS(@PathVariable int id) {
+        try {
+            boolean isDeleted = memberService.deleteMemberSNS(id);
+            if (isDeleted) {
+                return ResponseEntity.ok("SNS 링크 삭제 성공");
+            } else {
+                return ResponseEntity.ok("SNS 링크 삭제 실패: 해당 ID를 찾을 수 없음");
+            }
+        } catch (Exception e) {
+            return ResponseEntity.ok("SNS 링크 삭제 실패: " + e.getMessage());
         }
     }
 
@@ -45,7 +86,7 @@ public class MemberController {
         try {
             boolean isDeleted = memberService.deleteMember(memberDTO.getId());
             if (isDeleted) {
-                return ResponseEntity.ok( memberDTO.getId() + "삭제");
+                return ResponseEntity.ok(memberDTO.getId() + " 삭제");
             } else {
                 return ResponseEntity.ok("멤버 삭제 실패: 해당 ID를 찾을 수 없음");
             }

--- a/src/main/java/com/club/magazine_club_program/DTO/MemberDTO.java
+++ b/src/main/java/com/club/magazine_club_program/DTO/MemberDTO.java
@@ -3,20 +3,36 @@ package com.club.magazine_club_program.DTO;
 public class MemberDTO {
     private final int id;
     private String name;
+    private String snsLink;        
 
     public MemberDTO(int id, String name) {
         this.id = id;
         this.name = name;
     }
 
+    public MemberDTO(int id, String name, String snsLink) {
+        this.id = id;
+        this.name = name;
+        this.snsLink = snsLink;
+    }
+
     public int getId() {
         return id;
     }
+    
     public String getName() {
         return name;
     }
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getSnsLink() {
+        return (snsLink == null || snsLink.trim().isEmpty()) ? "링크없음" : snsLink;
+    }
+
+    public void setSnsLink(String snsLink) {
+        this.snsLink = snsLink;
     }
 }

--- a/src/main/java/com/club/magazine_club_program/Mapper/MemberInfoMapper.java
+++ b/src/main/java/com/club/magazine_club_program/Mapper/MemberInfoMapper.java
@@ -3,6 +3,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 import java.util.List;
 
@@ -10,19 +11,45 @@ import com.club.magazine_club_program.DTO.MemberDTO;
 
 @Mapper
 public interface MemberInfoMapper {
-    // 전체 멤버 조회
+    // 전체 멤버 조회 
     @Select("""
-        SELECT id, name
+        SELECT id, name, sns_link
         FROM MemberInfo
+        ORDER BY id
     """)
     List<MemberDTO> findAll();
 
+    // SNS 링크가 있는 멤버만 조회
+    @Select("""
+        SELECT id, name, sns_link
+        FROM MemberInfo
+        WHERE sns_link IS NOT NULL AND sns_link != ''
+        ORDER BY id
+    """)
+    List<MemberDTO> findMembersWithSNS();
+
     // 멤버 추가
     @Insert("""
-        INSERT INTO MemberInfo (name)
-        VALUES (#{name})
+        INSERT INTO MemberInfo (name, sns_link)
+        VALUES (#{name}, #{snsLink})
     """)
     int addMember(MemberDTO member);
+
+    // 멤버 SNS 링크 업데이트
+    @Update("""
+        UPDATE MemberInfo 
+        SET sns_link = #{snsLink}
+        WHERE id = #{id}
+    """)
+    int updateMemberSNS(MemberDTO member);
+
+    // 멤버 SNS 링크 삭제
+    @Update("""
+        UPDATE MemberInfo 
+        SET sns_link = NULL
+        WHERE id = #{id}
+    """)
+    int deleteMemberSNS(@Param("id") int id);
 
     // 멤버 삭제
     @Delete("""

--- a/src/main/java/com/club/magazine_club_program/Service/MemberService.java
+++ b/src/main/java/com/club/magazine_club_program/Service/MemberService.java
@@ -14,14 +14,29 @@ public class MemberService {
         this.memberInfoMapper = memberInfoMapper;
     }
 
-    // 모든 멤버 조회
+    // 모든 멤버 조회 (SNS 링크 포함)
     public List<MemberDTO> getAllMembers() {
         return memberInfoMapper.findAll();
     }
 
+    // SNS 링크가 있는 멤버만 조회
+    public List<MemberDTO> getMembersWithSNS() {
+        return memberInfoMapper.findMembersWithSNS();
+    }
+    
     // 신규 멤버 추가
     public void addMember(MemberDTO memberDTO) {
         memberInfoMapper.addMember(memberDTO);
+    }
+
+    // 멤버 SNS 링크 업데이트
+    public boolean updateMemberSNS(MemberDTO memberDTO) {
+        return memberInfoMapper.updateMemberSNS(memberDTO) > 0;
+    }
+
+    // 멤버 SNS 링크 삭제
+    public boolean deleteMemberSNS(int id) {
+        return memberInfoMapper.deleteMemberSNS(id) > 0;
     }
 
     // 멤버 삭제


### PR DESCRIPTION
회원 각자의 SNS에서 이미지 링크를 크롤링하는 기능도 추가하여 이미지 크롤러 브랜치에 업데이트하고, 
커밋을 병합해 메인 브랜치로 옮기려고 계획했지만,  
기능을 구현하는 과정에서 회원 개인 SNS 이미지 크롤링 기능이 없어도 될 것 같다는 의견이 나와 해당 기능을 넣지 않게 되었습니다.

회원들의 개인 아카이빙 SNS가 인스타그램, 벨로그, 네이버 블로그 등 지나치게 다양한 플랫폼이어서 크롤링 과정에서 모든 변수를 고려하기 어렵다는 기술적 측면의 문제도 있었습니다.